### PR TITLE
Feat/membership management

### DIFF
--- a/src/lib/tusktask/context/NotificationContext.tsx
+++ b/src/lib/tusktask/context/NotificationContext.tsx
@@ -34,6 +34,7 @@ import {
 import AlertDialog from "@/src/ui/components/tusktask/prefabs/AlertDialog";
 import { createNotification as createNotificationFn } from "../mutators/createtNotification";
 import { NotificationsPostRequest } from "@/app/api/notifications/post";
+import { Button } from "@/src/ui/components/shadcn/ui/button";
 
 interface TriggerToastProps extends ExternalToast {
   title: string;
@@ -354,6 +355,14 @@ const NotificationContextProvider = ({
           type: "default",
           title: "New Notification",
           description: "You have a new notification",
+          action: (
+            <Button
+              variant={"toaster"}
+              onClick={() => setNotificationsDialogOpen(true)}
+            >
+              Open
+            </Button>
+          ),
         });
       }
 

--- a/src/lib/tusktask/utils/timePassed.ts
+++ b/src/lib/tusktask/utils/timePassed.ts
@@ -24,6 +24,10 @@ export function timePassed(date: Date | string | undefined | null): string {
   } else if (minutes > 0) {
     return `${minutes} minute${minutes > 1 ? "s" : ""} ago`;
   } else {
-    return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
+    if (seconds < 1) {
+      return "Just now";
+    } else {
+      return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
+    }
   }
 }

--- a/src/ui/components/shadcn/ui/button.tsx
+++ b/src/ui/components/shadcn/ui/button.tsx
@@ -23,6 +23,8 @@ const buttonVariants = cva(
           "border text-muted-foreground hover:text-foreground hover:border capitalize",
         empty:
           "bg-transparent border-0 opacity-50 hover:opacity-100 transition-all duration-300",
+        toaster:
+          "text-xs h-8 ms-auto border bg-transparent text-foreground shadow-xs hover:bg-accent hover:text-accent-foreground",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/ui/components/tusktask/prefabs/MembershipCard/index.tsx
+++ b/src/ui/components/tusktask/prefabs/MembershipCard/index.tsx
@@ -42,7 +42,15 @@ const MembershipCard = ({ membership }: { membership: FullTeamMembers }) => {
   } = useTeamContext();
 
   // Pull setters and triggers from Notification context
-  const { triggerAlertDialog } = useNotificationContext();
+  const { triggerAlertDialog, sent } = useNotificationContext();
+
+  const sentAdminRequests = sent.filter(
+    (s) =>
+      s.receiverId === user.id &&
+      s.type === "adminRequest" &&
+      s.teamId === teamDetailKey &&
+      s.status === "not_read"
+  );
 
   // RBAC Helper Functions
   const isOwner = (role: string) => role === "owner";
@@ -215,13 +223,21 @@ const MembershipCard = ({ membership }: { membership: FullTeamMembers }) => {
             {canRequestAdminRights && (
               <PopoverAction
                 Icon={ShieldUser}
-                title="Request administration access"
+                title={
+                  sentAdminRequests.length === 0
+                    ? "Request administration access"
+                    : "Administration request sent"
+                }
                 onClick={() => {
+                  if (sentAdminRequests.length !== 0) return;
                   setAdminRequestDialog({
                     membership: membership,
                     open: true,
                   });
                 }}
+                variant={
+                  sentAdminRequests.length === 0 ? "default" : "disabled"
+                }
               />
             )}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Toast notifications now include an "Open" button, allowing users to directly open the notifications dialog from the toast.
  - The "Request administration access" button on membership cards now dynamically updates its label and disables itself if an admin request is already pending.

- **Style**
  - Added a new "toaster" button style for improved visual consistency in toast notifications.

- **Bug Fixes**
  - Time differences of less than one second now display as "Just now" instead of "0 seconds ago".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->