### PR TITLE
feat: add projects get api endpoint

### DIFF
--- a/app/api/projects/get.ts
+++ b/app/api/projects/get.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { createResponse } from "@/src/lib/utils/createResponse";
+import { and, eq, ilike } from "drizzle-orm";
+import { projects } from "@/src/db/schema/projects";
+import { createServerClient } from "@/src/lib/supabase/instances/server";
+import { db } from "@/src/db";
+import { OperationError } from "@/src/lib/errors";
+
+const PATH = "API_PROJECTS_GET";
+
+export interface ProjectsGetRequest {
+  id?: string;
+  name?: string;
+}
+
+export async function projectsGet(req: NextRequest) {
+  // Extract parameters
+  const url = req.nextUrl;
+  const { id, name } = Object.fromEntries(
+    url.searchParams.entries()
+  ) as ProjectsGetRequest;
+
+  // Validate Session
+  const supabase = await createServerClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data?.user;
+
+  if (!user) {
+    return createResponse(
+      401,
+      "unauthorized",
+      "Invalid session, login required",
+      undefined
+    );
+  }
+
+  // Query Construction
+  const query = [];
+
+  // Always search by owner
+  query.push(eq(projects.ownerId, user.id));
+
+  if (id) {
+    query.push(eq(projects.id, id));
+  }
+
+  if (name) {
+    query.push(ilike(projects.name, `%${name}%`));
+  }
+
+  // Executions
+  try {
+    const response = await db.query.projects.findMany({
+      where: and(...query),
+    });
+
+    const isFound = response.length > 0;
+
+    return createResponse(
+      isFound ? 200 : 404,
+      isFound ? "success" : "not_found",
+      isFound ? "Success fetched projects" : "No such project",
+      response
+    );
+  } catch (error) {
+    return createResponse(
+      500,
+      (error as OperationError)?.code ?? "Unknown error",
+      (error as OperationError)?.message ?? "Unknown error",
+      undefined,
+      true,
+      `${PATH}:${JSON.stringify(error)}`
+    );
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,3 @@
+import { projectsGet } from "./get";
+
+export { projectsGet as GET };

--- a/app/auth/email/confirmed/page.tsx
+++ b/app/auth/email/confirmed/page.tsx
@@ -18,9 +18,9 @@ export const metadata: Metadata = generateMetadata({
 const EmailConfirmedPage = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ email: string }>;
+  searchParams: Promise<{ email: string; code: string }>;
 }) => {
-  const { email } = await searchParams;
+  const { email, code } = await searchParams;
 
   return (
     <div className="max-w-md p-4">
@@ -54,7 +54,9 @@ const EmailConfirmedPage = async ({
 
       {/* Login button */}
       <Button className="w-full block text-center mt-6" asChild>
-        <Link href={"/auth"}>Sign In</Link>
+        <Link href={code ? `/auth/callback?code=${code}` : "/auth"}>
+          Sign In
+        </Link>
       </Button>
 
       {/* Helper Bar */}

--- a/app/auth/registration/RegistrationPageIndex.tsx
+++ b/app/auth/registration/RegistrationPageIndex.tsx
@@ -36,6 +36,12 @@ const RegistrationPageIndex = () => {
 
       // Run Renderer
       renderer(setter, userMetadata.registration_phase);
+    } else {
+      // Fallback if registrationPhase is not exist
+      setter({ registrationPhase: "name" });
+
+      // Run Renderer
+      renderer(setter, "name");
     }
   }, [setter, session, isFetchingSession, refetchSession]);
 

--- a/app/auth/registration/phases/ConfirmationPhase.tsx
+++ b/app/auth/registration/phases/ConfirmationPhase.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { DEFAULT_NO_IMAGE_SQUARE } from "@/src/lib/configs";
 import { useSession } from "@/src/lib/hooks/auth/useAuth";
 import { useMutateUserMetadata } from "@/src/lib/hooks/mutations/useMutateUserMetadata";
@@ -6,9 +8,12 @@ import { Button } from "@/src/ui/shadcn/components/ui/button";
 import { Skeleton } from "@/src/ui/shadcn/components/ui/skeleton";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import React from "react";
+import React, { useState } from "react";
 
 const ConfirmationPhase = () => {
+  // Loading State
+  const [isLoading, setIsLoading] = useState(false);
+
   // Pull Session
   const { data: session } = useSession();
 
@@ -48,8 +53,9 @@ const ConfirmationPhase = () => {
             </div>
             <Button
               variant={"default"}
-              disabled={isMutatingUserMetadata}
+              disabled={isMutatingUserMetadata || isLoading}
               onClick={() => {
+                setIsLoading(true); // Doesn't need to set to false as user should've redirected to /dashboard
                 mutateUserMetadata(
                   {
                     registration_phase: "completed",
@@ -58,11 +64,14 @@ const ConfirmationPhase = () => {
                     onSuccess: () => {
                       router.refresh();
                     },
+                    onError: () => {
+                      setIsLoading(false); // Set false if somehing goes wrong
+                    },
                   }
                 );
               }}
             >
-              {isMutatingUserMetadata ? "Processing" : "Good Enough"}
+              {isLoading ? "Saving Your Changes" : "Good Enough"}
             </Button>
           </div>
         </div>

--- a/src/db/migrations/0004_glamorous_talos.sql
+++ b/src/db/migrations/0004_glamorous_talos.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "project"."projects" ALTER COLUMN "owner_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "project"."projects" ALTER COLUMN "name" SET DEFAULT 'My Project';--> statement-breakpoint
+ALTER TABLE "project"."projects" ALTER COLUMN "icon" SET DEFAULT 'File';

--- a/src/db/migrations/0005_long_living_lightning.sql
+++ b/src/db/migrations/0005_long_living_lightning.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "project"."projects" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/src/db/migrations/meta/0004_snapshot.json
+++ b/src/db/migrations/meta/0004_snapshot.json
@@ -1,0 +1,672 @@
+{
+  "id": "307bd988-93cf-4108-8ef3-c5344582ec32",
+  "prevId": "4e26c765-f08c-44ba-8998-6847219a018e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "user.profiles": {
+      "name": "profiles",
+      "schema": "user",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UIDX_USER_PROFILES_USERNAME": {
+          "name": "UIDX_USER_PROFILES_USERNAME",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_USER_PROFILES_NAME": {
+          "name": "FTS_USER_PROFILES_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_USER_PROFILES_SELECT_AUTHENTICATED": {
+          "name": "PLC_USER_PROFILES_SELECT_AUTHENTICATED",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": ""
+        },
+        "PLC_USER_PROFILES_UPDATE_SELF": {
+          "name": "PLC_USER_PROFILES_UPDATE_SELF",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(SELECT auth.uid()) = \"user\".\"profiles\".\"user_id\"",
+          "withCheck": "(SELECT auth.uid()) = \"user\".\"profiles\".\"user_id\""
+        },
+        "PLC_USER_PROFILES_ALL_SERVICE": {
+          "name": "PLC_USER_PROFILES_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.projects": {
+      "name": "projects",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectType": {
+          "name": "projectType",
+          "type": "project_Type",
+          "typeSchema": "project",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'My Project'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'File'"
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_PROJECTS_OWNER_ID": {
+          "name": "IDX_PROJECT_PROJECTS_OWNER_ID",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_PROJECTS_NAME": {
+          "name": "FTS_PROJECT_PROJECTS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_profiles_user_id_fk": {
+          "name": "projects_owner_id_profiles_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_PROJECTS_ALL_SELF": {
+          "name": "PLC_PROJECT_PROJECTS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"projects\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"projects\".\"owner_id\""
+        },
+        "PLC_PROJECT_PROJECTS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_PROJECTS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.master_tasks": {
+      "name": "master_tasks",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r_rule": {
+          "name": "r_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_MASTER_TASKS_CREATED_AT": {
+          "name": "IDX_PROJECT_MASTER_TASKS_CREATED_AT",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_MASTER_TASKS_NAME": {
+          "name": "FTS_PROJECT_MASTER_TASKS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "master_tasks_owner_id_profiles_user_id_fk": {
+          "name": "master_tasks_owner_id_profiles_user_id_fk",
+          "tableFrom": "master_tasks",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_MASTER_TASKS_ALL_SELF": {
+          "name": "PLC_PROJECT_MASTER_TASKS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"master_tasks\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"master_tasks\".\"owner_id\""
+        },
+        "PLC_PROJECT_MASTER_TASKS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_MASTER_TASKS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.tasks": {
+      "name": "tasks",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_task": {
+          "name": "master_task",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_task": {
+          "name": "parent_task",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskStatus": {
+          "name": "taskStatus",
+          "type": "task_status",
+          "typeSchema": "project",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_at": {
+          "name": "reminder_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_TASKS_OWNER_ID": {
+          "name": "IDX_PROJECT_TASKS_OWNER_ID",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_PROJECT_ID": {
+          "name": "IDX_PROJECT_TASKS_PROJECT_ID",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_TASK_STATUS": {
+          "name": "IDX_PROJECT_TASKS_TASK_STATUS",
+          "columns": [
+            {
+              "expression": "taskStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_CREATED_AT": {
+          "name": "IDX_PROJECT_TASKS_CREATED_AT",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_REMINDER_AT": {
+          "name": "IDX_PROJECT_TASKS_REMINDER_AT",
+          "columns": [
+            {
+              "expression": "reminder_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_DEADLINE_AT": {
+          "name": "IDX_PROJECT_TASKS_DEADLINE_AT",
+          "columns": [
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_TASKS_NAME": {
+          "name": "FTS_PROJECT_TASKS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsVector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_owner_id_profiles_user_id_fk": {
+          "name": "tasks_owner_id_profiles_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_master_task_master_tasks_id_fk": {
+          "name": "tasks_master_task_master_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "master_tasks",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "master_task"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SR_PROJECT_TASKS_PARENT_TASK_ID": {
+          "name": "SR_PROJECT_TASKS_PARENT_TASK_ID",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "parent_task"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_TASKS_ALL_SELF": {
+          "name": "PLC_PROJECT_TASKS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"tasks\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"tasks\".\"owner_id\""
+        },
+        "PLC_PROJECT_TASKS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_TASKS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "project.project_Type": {
+      "name": "project_Type",
+      "schema": "project",
+      "values": [
+        "primary",
+        "generic",
+        "co-op"
+      ]
+    },
+    "project.task_status": {
+      "name": "task_status",
+      "schema": "project",
+      "values": [
+        "pending",
+        "archived",
+        "on_process",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {
+    "project": "project",
+    "user": "user"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0005_snapshot.json
+++ b/src/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,679 @@
+{
+  "id": "4e3ca0b7-58e2-4f95-8acf-ebd85398d2d8",
+  "prevId": "307bd988-93cf-4108-8ef3-c5344582ec32",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "user.profiles": {
+      "name": "profiles",
+      "schema": "user",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UIDX_USER_PROFILES_USERNAME": {
+          "name": "UIDX_USER_PROFILES_USERNAME",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_USER_PROFILES_NAME": {
+          "name": "FTS_USER_PROFILES_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_USER_PROFILES_SELECT_AUTHENTICATED": {
+          "name": "PLC_USER_PROFILES_SELECT_AUTHENTICATED",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": ""
+        },
+        "PLC_USER_PROFILES_UPDATE_SELF": {
+          "name": "PLC_USER_PROFILES_UPDATE_SELF",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(SELECT auth.uid()) = \"user\".\"profiles\".\"user_id\"",
+          "withCheck": "(SELECT auth.uid()) = \"user\".\"profiles\".\"user_id\""
+        },
+        "PLC_USER_PROFILES_ALL_SERVICE": {
+          "name": "PLC_USER_PROFILES_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.projects": {
+      "name": "projects",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projectType": {
+          "name": "projectType",
+          "type": "project_Type",
+          "typeSchema": "project",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'My Project'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'File'"
+        },
+        "cover": {
+          "name": "cover",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_PROJECTS_OWNER_ID": {
+          "name": "IDX_PROJECT_PROJECTS_OWNER_ID",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_PROJECTS_NAME": {
+          "name": "FTS_PROJECT_PROJECTS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_profiles_user_id_fk": {
+          "name": "projects_owner_id_profiles_user_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_PROJECTS_ALL_SELF": {
+          "name": "PLC_PROJECT_PROJECTS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"projects\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"projects\".\"owner_id\""
+        },
+        "PLC_PROJECT_PROJECTS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_PROJECTS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.master_tasks": {
+      "name": "master_tasks",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r_rule": {
+          "name": "r_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_MASTER_TASKS_CREATED_AT": {
+          "name": "IDX_PROJECT_MASTER_TASKS_CREATED_AT",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_MASTER_TASKS_NAME": {
+          "name": "FTS_PROJECT_MASTER_TASKS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsvector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "master_tasks_owner_id_profiles_user_id_fk": {
+          "name": "master_tasks_owner_id_profiles_user_id_fk",
+          "tableFrom": "master_tasks",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_MASTER_TASKS_ALL_SELF": {
+          "name": "PLC_PROJECT_MASTER_TASKS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"master_tasks\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"master_tasks\".\"owner_id\""
+        },
+        "PLC_PROJECT_MASTER_TASKS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_MASTER_TASKS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "project.tasks": {
+      "name": "tasks",
+      "schema": "project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "master_task": {
+          "name": "master_task",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_task": {
+          "name": "parent_task",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Untitled'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taskStatus": {
+          "name": "taskStatus",
+          "type": "task_status",
+          "typeSchema": "project",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_at": {
+          "name": "reminder_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deadline_at": {
+          "name": "deadline_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "IDX_PROJECT_TASKS_OWNER_ID": {
+          "name": "IDX_PROJECT_TASKS_OWNER_ID",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_PROJECT_ID": {
+          "name": "IDX_PROJECT_TASKS_PROJECT_ID",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_TASK_STATUS": {
+          "name": "IDX_PROJECT_TASKS_TASK_STATUS",
+          "columns": [
+            {
+              "expression": "taskStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_CREATED_AT": {
+          "name": "IDX_PROJECT_TASKS_CREATED_AT",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_REMINDER_AT": {
+          "name": "IDX_PROJECT_TASKS_REMINDER_AT",
+          "columns": [
+            {
+              "expression": "reminder_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "IDX_PROJECT_TASKS_DEADLINE_AT": {
+          "name": "IDX_PROJECT_TASKS_DEADLINE_AT",
+          "columns": [
+            {
+              "expression": "deadline_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FTS_PROJECT_TASKS_NAME": {
+          "name": "FTS_PROJECT_TASKS_NAME",
+          "columns": [
+            {
+              "expression": "to_tsVector('simple', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_owner_id_profiles_user_id_fk": {
+          "name": "tasks_owner_id_profiles_user_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "profiles",
+          "schemaTo": "user",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_master_task_master_tasks_id_fk": {
+          "name": "tasks_master_task_master_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "master_tasks",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "master_task"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SR_PROJECT_TASKS_PARENT_TASK_ID": {
+          "name": "SR_PROJECT_TASKS_PARENT_TASK_ID",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "schemaTo": "project",
+          "columnsFrom": [
+            "parent_task"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "PLC_PROJECT_TASKS_ALL_SELF": {
+          "name": "PLC_PROJECT_TASKS_ALL_SELF",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(select auth.uid()) = \"project\".\"tasks\".\"owner_id\"",
+          "withCheck": "(select auth.uid()) = \"project\".\"tasks\".\"owner_id\""
+        },
+        "PLC_PROJECT_TASKS_ALL_SERVICE": {
+          "name": "PLC_PROJECT_TASKS_ALL_SERVICE",
+          "as": "PERMISSIVE",
+          "for": "ALL",
+          "to": [
+            "service_role"
+          ],
+          "using": ""
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    }
+  },
+  "enums": {
+    "project.project_Type": {
+      "name": "project_Type",
+      "schema": "project",
+      "values": [
+        "primary",
+        "generic",
+        "co-op"
+      ]
+    },
+    "project.task_status": {
+      "name": "task_status",
+      "schema": "project",
+      "values": [
+        "pending",
+        "archived",
+        "on_process",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {
+    "project": "project",
+    "user": "user"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -29,6 +29,20 @@
       "when": 1759423043285,
       "tag": "0003_lethal_miss_america",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1759427341882,
+      "tag": "0004_glamorous_talos",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1759427458516,
+      "tag": "0005_long_living_lightning",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/projects.ts
+++ b/src/db/schema/projects.ts
@@ -1,4 +1,4 @@
-import { index, pgPolicy, text, uuid } from "drizzle-orm/pg-core";
+import { index, pgPolicy, text, timestamp, uuid } from "drizzle-orm/pg-core";
 import { projectSchema } from "./configs";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { relations, sql } from "drizzle-orm";
@@ -21,14 +21,19 @@ export const projects = projectSchema
       id: uuid("id")
         .primaryKey()
         .$defaultFn(() => crypto.randomUUID()),
-      ownerId: uuid("owner_id").references(() => profiles.userId, {
-        onDelete: "cascade",
-      }),
+      ownerId: uuid("owner_id")
+        .references(() => profiles.userId, {
+          onDelete: "cascade",
+        })
+        .notNull(),
       projectType: projectTypeEnum(),
-      name: text("name").notNull(),
+      name: text("name").notNull().default("My Project"),
       description: text("description"),
-      icon: text("icon"),
+      icon: text("icon").default("File"),
       cover: text("cover"),
+      createdAt: timestamp("created_at", { withTimezone: true })
+        .notNull()
+        .defaultNow(),
     },
     (t) => [
       // Indexes


### PR DESCRIPTION
- Created a new API route for fetching projects.
- Updated the email confirmation page to include a verification code in the search parameters.
- Modified the registration page to handle cases where the registration phase is not defined.
- Enhanced the confirmation phase to manage loading states during user metadata mutation.
- Added database migrations to enforce constraints and defaults on the projects table.
- Updated the projects schema to include a created_at timestamp and set default values for name and icon.