### PR TITLE
Refactor: Move Pomodoro Counter to Web Worker

### DIFF
--- a/app/PomodoroProvider.tsx
+++ b/app/PomodoroProvider.tsx
@@ -1,77 +1,84 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNotificationStore } from "@/src/lib/stores/notification";
 import { usePomodoroStore } from "@/src/lib/stores/pomodoro";
 import { formatDurationLuxon } from "@/src/lib/utils/formatTime";
 import PomodoroDialog from "@/src/ui/components/ui/PomodoroDialog";
 
-const PomodoroProvider = ({
-  children,
-}: {
-  children: Readonly<React.ReactNode>;
-}) => {
+const PomodoroProvider = ({ children }: { children: React.ReactNode }) => {
   const {
     currentPhase,
-    elapsedTime,
     focusTime,
-    isRunning,
     restTime,
+    isRunning,
     setIsStarted,
+    elapsedTime,
   } = usePomodoroStore();
 
   const { triggerSound } = useNotificationStore();
 
-  useEffect(() => {
-    const totalDuration = currentPhase === "focus" ? focusTime : restTime;
+  // Create worker instance once
+  const workerRef = useRef<Worker | null>(null);
 
-    let interval: NodeJS.Timeout | null;
+  if (!workerRef.current && typeof window !== "undefined") {
+    workerRef.current = new Worker(
+      new URL("@/src/lib/workers/pomodoro.worker.js", import.meta.url),
+    );
+  }
+
+  // Listen to worker messages once
+  useEffect(() => {
+    if (!workerRef.current) return;
+
+    workerRef.current.onmessage = (e) => {
+      const { type, elapsed } = e.data;
+
+      if (type === "TICK") {
+        usePomodoroStore.setState({ elapsedTime: elapsed });
+
+        const totalDuration = currentPhase === "focus" ? focusTime : restTime;
+        const timeLeft = totalDuration - elapsed;
+
+        document.title = `${formatDurationLuxon(timeLeft)} | ${
+          currentPhase === "focus" ? "Focus" : "Rest"
+        }`;
+      }
+
+      if (type === "COMPLETE") {
+        triggerSound("alarm");
+
+        usePomodoroStore.setState((state) => ({
+          currentPhase: state.currentPhase === "focus" ? "rest" : "focus",
+          elapsedTime: 0,
+          isRunning: false,
+          dialogOpen: true,
+        }));
+
+        document.title = `It's time to ${
+          currentPhase === "focus" ? "Rest" : "Focus"
+        }`;
+      }
+    };
+  }, [currentPhase, focusTime, restTime, triggerSound]);
+
+  // Start / Stop worker
+  useEffect(() => {
+    if (!workerRef.current) return;
+
+    const totalDuration = currentPhase === "focus" ? focusTime : restTime;
 
     if (isRunning) {
       setIsStarted(true);
 
-      interval = setInterval(() => {
-        usePomodoroStore.setState((state) => {
-          const newElapsedTime = state.elapsedTime + 500;
-          const timeLeft = totalDuration - elapsedTime;
-          const isCompleted = timeLeft <= 0;
-
-          if (isCompleted) {
-            document.title = `It's Time To ${currentPhase === "focus" ? "Rest" : "Focus"}`;
-
-            triggerSound("alarm");
-
-            return {
-              currentPhase: currentPhase === "focus" ? "rest" : "focus",
-              elapsedTime: 0,
-              isRunning: false,
-              dialogOpen: true,
-            };
-          }
-
-          document.title = `${formatDurationLuxon(timeLeft)} | ${currentPhase === "focus" ? "Focus" : "Rest"}`;
-
-          return {
-            elapsedTime: newElapsedTime,
-          };
-        });
-      }, 500);
+      workerRef.current.postMessage({
+        type: "START",
+        payload: { duration: totalDuration, elapsed: elapsedTime },
+      });
+    } else {
+      workerRef.current.postMessage({ type: "STOP" });
     }
-
-    return () => {
-      if (interval) {
-        clearInterval(interval);
-      }
-    };
-  }, [
-    isRunning,
-    focusTime,
-    restTime,
-    elapsedTime,
-    setIsStarted,
-    currentPhase,
-    triggerSound,
-  ]);
+  }, [isRunning, currentPhase, focusTime, restTime, setIsStarted, elapsedTime]);
 
   return (
     <>

--- a/src/lib/workers/pomodoro.worker.js
+++ b/src/lib/workers/pomodoro.worker.js
@@ -1,0 +1,42 @@
+let interval = null;
+let startTimestamp = 0;
+let duration = 0;
+let lastElapsed = 0;
+
+self.onmessage = (e) => {
+  const { type, payload } = e.data;
+
+  if (type === "START") {
+    duration = payload.duration;
+    lastElapsed = payload?.elapsed ?? 0;
+    startTimestamp = Date.now() - lastElapsed;
+
+    if (interval) clearInterval(interval);
+
+    interval = setInterval(() => {
+      const elapsed = Date.now() - startTimestamp;
+
+      if (elapsed >= duration) {
+        clearInterval(interval);
+        self.postMessage({
+          type: "COMPLETE",
+        });
+      } else {
+        self.postMessage({
+          type: "TICK",
+          elapsed,
+        });
+      }
+    }, 250);
+  }
+
+  if (type === "STOP") {
+    if (interval) clearInterval(interval);
+  }
+
+  if (type === "RESET") {
+    if (interval) clearInterval(interval);
+    startTimestamp = 0;
+    duration = 0;
+  }
+};

--- a/src/ui/components/ui/ProfileDialog/index.tsx
+++ b/src/ui/components/ui/ProfileDialog/index.tsx
@@ -7,7 +7,9 @@ import {
   SwatchBook,
 } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import type { HTMLAttributeAnchorTarget } from "react";
+import { authClient } from "@/src/lib/auth/client";
 import { useGetSelfProfile } from "@/src/lib/queries/hooks/useGetSelfProfile";
 import { useProfileDialogStore } from "@/src/lib/stores/profileDialog";
 import { Avatar, AvatarImage } from "@/src/ui/shadcn/components/ui/avatar";
@@ -104,6 +106,7 @@ const ButtonItem = ({
 const ProfileDialog = () => {
   const { data: profile, isPending: _isLoadingProfile } = useGetSelfProfile();
   const { open, setOpen: onOpenChange } = useProfileDialogStore();
+  const router = useRouter();
 
   return (
     <Dialog {...{ open, onOpenChange }}>
@@ -161,7 +164,15 @@ const ProfileDialog = () => {
             <ButtonItem
               icon={LogOut}
               title="Sign Out"
-              onClick={() => {}}
+              onClick={async () => {
+                await authClient.signOut({
+                  fetchOptions: {
+                    onSuccess: () => {
+                      router.push("/auth");
+                    },
+                  },
+                });
+              }}
               className="text-destructive hover:bg-destructive hover:text-destructive-foreground"
             />
           </div>


### PR DESCRIPTION
Prevent set interval throttling by using Web Worker for Pomodoro counter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timer moved to a background worker for smoother, more accurate ticking.
  * Tab title now shows remaining time and current phase.
  * Timer start/stop/resume behavior improved; completion triggers sound and opens the end-of-session dialog.

* **Bug Fixes**
  * Sign-out now performs async logout and redirects users correctly after logout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->