### PR TITLE
Add Account Deletion Mechanism

### DIFF
--- a/app/account/deleted/AccountDeletedPageIndex.tsx
+++ b/app/account/deleted/AccountDeletedPageIndex.tsx
@@ -71,10 +71,13 @@ const AccountDeletedPageIndex = () => {
                   fetchOptions: {
                     onSuccess: () => {
                       router.push("/auth");
+                      setIsLoading(false)
                     },
+                    onError: () => {
+                      setIsLoading(false)
+                    }
                   },
                 });
-                setIsLoading(false);
               }}
               disabled={isLoading || isUpdatingProfile}
             >
@@ -95,7 +98,6 @@ const AccountDeletedPageIndex = () => {
           onClick: () => {
             if (isLoading || isUpdatingProfile) return;
 
-            setIsLoading(true);
             updateProfile(
               { deletedAt: null },
               {
@@ -123,7 +125,6 @@ const AccountDeletedPageIndex = () => {
                 },
               },
             );
-            setIsLoading(false);
           },
         }}
       />

--- a/app/account/deleted/AccountDeletedPageIndex.tsx
+++ b/app/account/deleted/AccountDeletedPageIndex.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { authClient } from "@/src/lib/auth/client";
+import { useGetSelfProfile } from "@/src/lib/queries/hooks/useGetSelfProfile";
+import { useUpdateUserProfile } from "@/src/lib/queries/hooks/useUpdateUserProfile";
+import { useNotificationStore } from "@/src/lib/stores/notification";
+import TwoChoiceDialog from "@/src/ui/components/ui/TwoChoiceDialog";
+import { Button } from "@/src/ui/shadcn/components/ui/button";
+
+const AccountDeletedPageIndex = () => {
+  const { data: profile, isPending: isLoadingProfile } = useGetSelfProfile();
+
+  const { triggerToast } = useNotificationStore();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  const [abortDialog, setAbortDialog] = useState(false);
+
+  const { mutate: updateProfile, isPending: isUpdatingProfile } =
+    useUpdateUserProfile();
+
+  useEffect(() => {
+    if (!isLoadingProfile && !profile?.result?.deletedAt) {
+      router.push("/dashboard");
+    }
+  }, [profile, isLoadingProfile, router]);
+
+  return (
+    <>
+      <div className="min-h-dvh max-h-dvh flex-center">
+        {/* Wrapper */}
+        <div className="grid grid-cols-1 gap-6 text-center">
+          <header>
+            <h1 className="text-2xl font-semibold">
+              Account Deletion Scheduled
+            </h1>
+            <p>Your account will be deleted in a couple of days.</p>
+          </header>
+
+          {/* Illo */}
+          <div className="relative aspect-video">
+            <Image
+              layout="fill"
+              src={
+                "https://zvgpixcwdvbogm3e.public.blob.vercel-storage.com/tusktask/arts/tusky-bureaucrat-001.webp"
+              }
+              alt="Tusky Bureaucrat"
+              className="rounded-2xl border-4 animate-pulse"
+            />
+          </div>
+
+          {/* Actions */}
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              onClick={() => {
+                setAbortDialog(true);
+              }}
+              disabled={isUpdatingProfile || isLoading}
+            >
+              Abort Deletion
+            </Button>
+            <Button
+              variant={"outline"}
+              onClick={async () => {
+                setIsLoading(true);
+                await authClient.signOut({
+                  fetchOptions: {
+                    onSuccess: () => {
+                      router.push("/auth");
+                    },
+                  },
+                });
+                setIsLoading(false);
+              }}
+              disabled={isLoading || isUpdatingProfile}
+            >
+              Sign Out
+            </Button>
+          </div>
+        </div>
+      </div>
+      <TwoChoiceDialog
+        title="Abort Deletion"
+        description="Abort account deletion and recover your data?"
+        positiveText="Abort"
+        negativeText="Cancel"
+        open={abortDialog}
+        setOpen={setAbortDialog}
+        positiveProps={{
+          disabled: isLoading || isUpdatingProfile,
+          onClick: () => {
+            if (isLoading || isUpdatingProfile) return;
+
+            setIsLoading(true);
+            updateProfile(
+              { deletedAt: null },
+              {
+                onSuccess: () => {
+                  triggerToast(
+                    "Account Deletion Aborted",
+                    {
+                      description:
+                        "Deletion schedule is aborted, your data is recovered. Welcome back!",
+                    },
+                    "success",
+                  );
+
+                  router.push("/dashboard");
+                },
+                onError: () => {
+                  triggerToast(
+                    "Failed to Abort Account Deletion",
+                    {
+                      description:
+                        "Something went wrong, please contact developer is this issue persist!",
+                    },
+                    "error",
+                  );
+                },
+              },
+            );
+            setIsLoading(false);
+          },
+        }}
+      />
+    </>
+  );
+};
+
+export default AccountDeletedPageIndex;

--- a/app/account/deleted/AccountDeletedPageIndex.tsx
+++ b/app/account/deleted/AccountDeletedPageIndex.tsx
@@ -71,11 +71,11 @@ const AccountDeletedPageIndex = () => {
                   fetchOptions: {
                     onSuccess: () => {
                       router.push("/auth");
-                      setIsLoading(false)
+                      setIsLoading(false);
                     },
                     onError: () => {
-                      setIsLoading(false)
-                    }
+                      setIsLoading(false);
+                    },
                   },
                 });
               }}
@@ -118,7 +118,7 @@ const AccountDeletedPageIndex = () => {
                     "Failed to Abort Account Deletion",
                     {
                       description:
-                        "Something went wrong, please contact developer is this issue persist!",
+                        "Something went wrong, please contact developer if this issue persist!",
                     },
                     "error",
                   );

--- a/app/account/deleted/page.tsx
+++ b/app/account/deleted/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import AccountDeletedPageIndex from "./AccountDeletedPageIndex";
+
+export const metadata: Metadata = {
+  title: "Account Deletion Scheduled | TuskTask",
+};
+
+const DeletedPage = () => {
+  return <AccountDeletedPageIndex />;
+};
+
+export default DeletedPage;

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -25,6 +25,10 @@ const DashboardLayout = ({
     useGetSelfProfile();
   const profile = profileData?.result;
 
+  if (!isLoadingProfile && profile?.deletedAt) {
+    redirect("/account/deleted");
+  }
+
   if (!isLoadingProfile && profile?.onboardingStatus !== "completed") {
     redirect("/onboarding");
   }

--- a/app/dashboard/settings/components/DeleteAccount.tsx
+++ b/app/dashboard/settings/components/DeleteAccount.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { Trash } from "lucide-react";
+import { useState } from "react";
+import { useUpdateUserProfile } from "@/src/lib/queries/hooks/useUpdateUserProfile";
+import { useNotificationStore } from "@/src/lib/stores/notification";
+import SensitiveConfirmationDialog from "@/src/ui/components/ui/SensitiveConfirmationDialog";
+import SettingsItem from "@/src/ui/components/ui/SettingsItem";
+import { Button } from "@/src/ui/shadcn/components/ui/button";
+
+const DeleteAccount = () => {
+  const { triggerToast } = useNotificationStore();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [isValid, setIsvalid] = useState(false);
+
+  const { mutate: updateProfile, isPending: isUpdatingProfile } =
+    useUpdateUserProfile();
+
+  return (
+    <div>
+      <SettingsItem
+        icon={Trash}
+        title="Delete Account"
+        description="Delete your TuskTask account"
+        destructive
+      >
+        <Button
+          className="text-xs"
+          variant={"destructive"}
+          size={"sm"}
+          onClick={() => {
+            setDialogOpen(true);
+          }}
+          disabled={isUpdatingProfile}
+        >
+          Delete
+        </Button>
+      </SettingsItem>
+
+      <SensitiveConfirmationDialog
+        open={dialogOpen}
+        setOpen={setDialogOpen}
+        title="Delete Account"
+        description="Are you sure you want to delete your TuskTask account?"
+        isValid={isValid}
+        setIsValid={setIsvalid}
+        confirmationText="Delete My Account"
+        positiveText="Delete"
+        negativeText="Cancel"
+        positiveButtonProps={{
+          disabled: !isValid || isUpdatingProfile,
+          variant: "destructive",
+          onClick: () => {
+            if (!isValid || isUpdatingProfile) return;
+
+            updateProfile(
+              { deletedAt: new Date() },
+              {
+                onSuccess: () => {
+                  triggerToast(
+                    "Account Deletion Scheduled",
+                    {
+                      description:
+                        "Your account will be deleted in a couple of days",
+                    },
+                    "success",
+                  );
+                },
+                onError: () => {
+                  triggerToast(
+                    "Failed to Schedule Deletion",
+                    {
+                      description:
+                        "Something went wrong and we failed to schedule your account deletion.",
+                    },
+                    "error",
+                  );
+                },
+              },
+            );
+
+            setDialogOpen(false);
+          },
+        }}
+      />
+    </div>
+  );
+};
+
+export default DeleteAccount;

--- a/app/dashboard/settings/components/DeleteAccount.tsx
+++ b/app/dashboard/settings/components/DeleteAccount.tsx
@@ -58,6 +58,7 @@ const DeleteAccount = () => {
               { deletedAt: new Date() },
               {
                 onSuccess: () => {
+                  setDialogOpen(false);
                   triggerToast(
                     "Account Deletion Scheduled",
                     {
@@ -68,6 +69,8 @@ const DeleteAccount = () => {
                   );
                 },
                 onError: () => {
+                  setDialogOpen(false);
+
                   triggerToast(
                     "Failed to Schedule Deletion",
                     {
@@ -79,8 +82,6 @@ const DeleteAccount = () => {
                 },
               },
             );
-
-            setDialogOpen(false);
           },
         }}
       />

--- a/app/dashboard/settings/sections/AdvanceSection.tsx
+++ b/app/dashboard/settings/sections/AdvanceSection.tsx
@@ -1,6 +1,6 @@
-import { Trash } from "lucide-react";
-import SettingsItem from "@/src/ui/components/ui/SettingsItem";
-import { Button } from "@/src/ui/shadcn/components/ui/button";
+"use client";
+
+import DeleteAccount from "../components/DeleteAccount";
 import SectionHeader from "../components/SectionHeader";
 
 const AdvanceSection = () => {
@@ -12,16 +12,7 @@ const AdvanceSection = () => {
       />
 
       <div className="space-y-4">
-        <SettingsItem
-          icon={Trash}
-          title="Delete Account"
-          description="Delete your TuskTask account"
-          destructive
-        >
-          <Button className="text-xs" variant={"destructive"} size={"sm"}>
-            Delete
-          </Button>
-        </SettingsItem>
+        <DeleteAccount />
       </div>
     </section>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,11 +27,11 @@ export default function RootLayout({
             <ThemeProvider>
               <PomodoroProvider>{children}</PomodoroProvider>
             </ThemeProvider>
+            <ImageUploadModal />
+            <ColorThemePickerModal />
+            <Toaster richColors position="top-center" />
+            <ReactQueryDevtools initialIsOpen={false} />
           </NotificationProvider>
-          <ImageUploadModal />
-          <ColorThemePickerModal />
-          <Toaster richColors position="top-center" />
-          <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       </body>
     </html>

--- a/src/db/migrations/supabase/0006_previous_silk_fever.sql
+++ b/src/db/migrations/supabase/0006_previous_silk_fever.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "app_auth"."user" ADD COLUMN "deleted_at" timestamp (6) with time zone;--> statement-breakpoint
+CREATE INDEX "appAuth_user_deletedAt_idx" ON "app_auth"."user" USING btree ("deleted_at");

--- a/src/db/migrations/supabase/meta/0006_snapshot.json
+++ b/src/db/migrations/supabase/meta/0006_snapshot.json
@@ -1,0 +1,1554 @@
+{
+  "id": "fe983bd2-8889-42c2-a36e-5d3edd31b25b",
+  "prevId": "497c3b5c-115d-4c42-8537-88d6464116fe",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app_auth.account": {
+      "name": "account",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.session": {
+      "name": "session",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.user": {
+      "name": "user",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "onboarding_status_enum",
+          "typeSchema": "app_auth",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme_enum",
+          "typeSchema": "app_auth",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "is_silent": {
+          "name": "is_silent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appAuth_user_deletedAt_idx": {
+          "name": "appAuth_user_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": ["username"]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.verification": {
+      "name": "verification",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image": {
+      "name": "image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "media_ownership_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_owned'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "media_storage": {
+          "name": "media_storage",
+          "type": "media_storage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_image_name_fts": {
+          "name": "public_image_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_image_tags_idx": {
+          "name": "public_image_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_image_ownerId_idx": {
+          "name": "public_image_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_image_deletedAt_idx": {
+          "name": "public_image_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_owner_id_user_id_fk": {
+          "name": "image_owner_id_user_id_fk",
+          "tableFrom": "image",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_receiver": {
+      "name": "notification_receiver",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_notificationReceiver_notificationId_idx": {
+          "name": "public_notificationReceiver_notificationId_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_notificationReceiver_userId_idx": {
+          "name": "public_notificationReceiver_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_receiver_notification_id_notification_id_fk": {
+          "name": "notification_receiver_notification_id_notification_id_fk",
+          "tableFrom": "notification_receiver",
+          "tableTo": "notification",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_receiver_user_id_user_id_fk": {
+          "name": "notification_receiver_user_id_user_id_fk",
+          "tableFrom": "notification_receiver",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "public_notificationReceiver_cpk": {
+          "name": "public_notificationReceiver_cpk",
+          "columns": ["notification_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "project_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_project_name_fts": {
+          "name": "public_project_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english',\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_project_type_idx": {
+          "name": "public_project_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_isPinned_idx": {
+          "name": "public_project_isPinned_idx",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_isArchived_idx": {
+          "name": "public_project_isArchived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_createdById_idx": {
+          "name": "public_project_createdById_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_ownerId_idx": {
+          "name": "public_project_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_createdAt_idx": {
+          "name": "public_project_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_updatedAt_idx": {
+          "name": "public_project_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_deletedAt_idx": {
+          "name": "public_project_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_created_by_id_user_id_fk": {
+          "name": "project_created_by_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_owner_id_user_id_fk": {
+          "name": "project_owner_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_membership": {
+      "name": "project_membership",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "project_membership_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_membership_project_id_project_id_fk": {
+          "name": "project_membership_project_id_project_id_fk",
+          "tableFrom": "project_membership",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_membership_user_id_user_id_fk": {
+          "name": "project_membership_user_id_user_id_fk",
+          "tableFrom": "project_membership",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "public_projectMembership_cpk": {
+          "name": "public_projectMembership_cpk",
+          "columns": ["project_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task": {
+      "name": "task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_id": {
+          "name": "claimed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_id": {
+          "name": "completed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_task_name_fts": {
+          "name": "public_task_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_task_priority_idx": {
+          "name": "public_task_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_status_idx": {
+          "name": "public_task_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_createdById_idx": {
+          "name": "public_task_createdById_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_ownerId_idx": {
+          "name": "public_task_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_claimedById_idx": {
+          "name": "public_task_claimedById_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_completedById_idx": {
+          "name": "public_task_completedById_idx",
+          "columns": [
+            {
+              "expression": "completed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_isPinned_idx": {
+          "name": "public_task_isPinned_idx",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_isArchived_idx": {
+          "name": "public_task_isArchived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_projectId_idx": {
+          "name": "public_task_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_parentId_idx": {
+          "name": "public_task_parentId_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_startAt_idx": {
+          "name": "public_task_startAt_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_endAt_idx": {
+          "name": "public_task_endAt_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_completedAt_idx": {
+          "name": "public_task_completedAt_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_createdAt_idx": {
+          "name": "public_task_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_updatedAt_idx": {
+          "name": "public_task_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_deletedAt_idx": {
+          "name": "public_task_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_created_by_id_user_id_fk": {
+          "name": "task_created_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["created_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_owner_id_user_id_fk": {
+          "name": "task_owner_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_claimed_by_id_user_id_fk": {
+          "name": "task_claimed_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["claimed_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_completed_by_id_user_id_fk": {
+          "name": "task_completed_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": ["completed_by_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_project_id_project_id_fk": {
+          "name": "task_project_id_project_id_fk",
+          "tableFrom": "task",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_task_parentId_fk": {
+          "name": "public_task_parentId_fk",
+          "tableFrom": "task",
+          "tableTo": "task",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.media_ownership_enum": {
+      "name": "media_ownership_enum",
+      "schema": "public",
+      "values": ["system", "user_owned"]
+    },
+    "public.media_storage": {
+      "name": "media_storage",
+      "schema": "public",
+      "values": ["internal", "external"]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "project_invitation",
+        "created_new_task",
+        "claimed_task",
+        "assigned_task",
+        "completed_task",
+        "rejected_invitation",
+        "joined_project",
+        "left_project",
+        "promoted_member",
+        "demoted_member",
+        "archived_task",
+        "updated_task",
+        "new_message",
+        "system_alert",
+        "generic_broadcast",
+        "system_broadcast",
+        "system_positive",
+        "system_negative"
+      ]
+    },
+    "app_auth.onboarding_status_enum": {
+      "name": "onboarding_status_enum",
+      "schema": "app_auth",
+      "values": ["name", "username", "image", "settings", "completed"]
+    },
+    "public.project_membership_type_enum": {
+      "name": "project_membership_type_enum",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "observer"]
+    },
+    "public.project_type_enum": {
+      "name": "project_type_enum",
+      "schema": "public",
+      "values": ["primary", "regular", "co-op"]
+    },
+    "public.task_status_enum": {
+      "name": "task_status_enum",
+      "schema": "public",
+      "values": ["pending", "on_process", "aborted", "delayed", "continued"]
+    },
+    "app_auth.theme_enum": {
+      "name": "theme_enum",
+      "schema": "app_auth",
+      "values": [
+        "default",
+        "dark",
+        "popBella",
+        "beigeSerenity",
+        "brownBear",
+        "coffeePuff",
+        "jetBlack"
+      ]
+    }
+  },
+  "schemas": {
+    "app_auth": "app_auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/supabase/meta/_journal.json
+++ b/src/db/migrations/supabase/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1765288760895,
       "tag": "0005_reflective_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1765458284636,
+      "tag": "0006_previous_silk_fever",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -5,32 +5,42 @@ import {
   createSelectSchema,
   createUpdateSchema,
 } from "drizzle-zod";
-import { appAuthSchema, onboardingStatusEnum, themeEnum } from "./configs";
+import {
+  appAuthSchema,
+  defaultTimestampConfig,
+  onboardingStatusEnum,
+  themeEnum,
+} from "./configs";
 import { image } from "./image";
 import { notificationReceiver } from "./notification";
 import { project, projectMembership } from "./project";
 import { task } from "./task";
 
-export const user = appAuthSchema.table("user", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  firstName: text("first_name"),
-  lastName: text("last_name"),
-  username: text("username").unique(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").default(false).notNull(),
-  image: text("image"),
-  onboardingStatus: onboardingStatusEnum("onboarding_status")
-    .notNull()
-    .default("name"),
-  theme: themeEnum("theme").notNull().default("default"),
-  isSilent: boolean("is_silent").notNull().default(false),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
-    .defaultNow()
-    .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull(),
-});
+export const user = appAuthSchema.table(
+  "user",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    firstName: text("first_name"),
+    lastName: text("last_name"),
+    username: text("username").unique(),
+    email: text("email").notNull().unique(),
+    emailVerified: boolean("email_verified").default(false).notNull(),
+    image: text("image"),
+    onboardingStatus: onboardingStatusEnum("onboarding_status")
+      .notNull()
+      .default("name"),
+    theme: themeEnum("theme").notNull().default("default"),
+    isSilent: boolean("is_silent").notNull().default(false),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+    deletedAt: timestamp("deleted_at", defaultTimestampConfig),
+  },
+  (t) => [index("appAuth_user_deletedAt_idx").on(t.deletedAt)],
+);
 
 export type UserType = typeof user.$inferSelect;
 export type InsertUserType = typeof user.$inferInsert;

--- a/src/lib/middlewares/withSessionMiddleware.ts
+++ b/src/lib/middlewares/withSessionMiddleware.ts
@@ -6,7 +6,7 @@ import {
 } from "next/server";
 import type { CustomMiddleware } from "./chain";
 
-const protectedRoutes = ["/dashboard", "/onboarding"];
+const protectedRoutes = ["/dashboard", "/onboarding", "/account/deleted"];
 const noSessionRoutes = ["/auth"];
 
 export function withSessionMiddleware(

--- a/src/ui/components/ui/SensitiveConfirmationDialog/index.tsx
+++ b/src/ui/components/ui/SensitiveConfirmationDialog/index.tsx
@@ -98,7 +98,7 @@ const SensitiveConfirmationDialog = ({
           />
         </div>
 
-        {/* Foote */}
+        {/* Footer */}
         <footer className="grid grid-cols-2 gap-2">
           <Button {...(positiveButtonProps || {})}>{positiveText}</Button>
           <DialogClose asChild>

--- a/src/ui/components/ui/SensitiveConfirmationDialog/index.tsx
+++ b/src/ui/components/ui/SensitiveConfirmationDialog/index.tsx
@@ -1,0 +1,115 @@
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { Button, type ButtonProps } from "@/src/ui/shadcn/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/src/ui/shadcn/components/ui/dialog";
+import Input, { type InputProps } from "../Input/input";
+
+export type SensitiveConfirmationDialogProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+
+  title: string;
+  description: string;
+
+  isValid: boolean;
+  setIsValid: (isValid: boolean) => void;
+
+  confirmationText: string;
+
+  inputProps?: InputProps;
+
+  positiveText: string;
+  negativeText: string;
+
+  positiveButtonProps?: ButtonProps;
+  negativeButtonProps?: ButtonProps;
+};
+
+const SensitiveConfirmationDialog = ({
+  open,
+  setOpen: onOpenChange,
+
+  title,
+  description,
+
+  confirmationText,
+
+  isValid,
+  setIsValid,
+
+  inputProps,
+
+  positiveText,
+  negativeText,
+
+  negativeButtonProps,
+  positiveButtonProps,
+}: SensitiveConfirmationDialogProps) => {
+  const { control, watch } = useForm({
+    mode: "onChange",
+    defaultValues: {
+      confirmation: "",
+    },
+  });
+
+  const confirmation = watch("confirmation");
+
+  useEffect(() => {
+    if (confirmation === confirmationText) {
+      setIsValid(true);
+    } else {
+      setIsValid(false);
+    }
+  }, [confirmation, setIsValid, confirmationText]);
+
+  return (
+    <Dialog {...{ open, onOpenChange }}>
+      <DialogContent className="space-y-4">
+        <DialogHeader className="m-0">
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {/* Confirmation Prompt */}
+        <div>
+          <Controller
+            control={control}
+            name="confirmation"
+            render={({ field }) => (
+              <Input
+                message={`Type "${confirmationText}" to continue`}
+                inputProps={{
+                  className: "text-center",
+                  ...field,
+                }}
+                messageProps={{
+                  className: `text-center ${!isValid && !!confirmation.length ? "text-destructive" : ""}`,
+                }}
+                {...(inputProps || {})}
+              />
+            )}
+          />
+        </div>
+
+        {/* Foote */}
+        <footer className="grid grid-cols-2 gap-2">
+          <Button {...(positiveButtonProps || {})}>{positiveText}</Button>
+          <DialogClose asChild>
+            <Button variant={"outline"} {...(negativeButtonProps || {})}>
+              {negativeText}
+            </Button>
+          </DialogClose>
+        </footer>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SensitiveConfirmationDialog;

--- a/src/ui/shadcn/components/ui/button.tsx
+++ b/src/ui/shadcn/components/ui/button.tsx
@@ -36,16 +36,18 @@ const buttonVariants = cva(
   },
 );
 
+export type ButtonProps = React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
+
 function Button({
   className,
   variant,
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean;
-  }) {
+}: ButtonProps) {
   const Comp = asChild ? Slot : "button";
 
   return (


### PR DESCRIPTION
Client side done, background worker still on the todo list. 

Also, add a new component: SensitiveConfirmationDialog where user need to type confirmation text before the positive button click able. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can schedule account deletion from settings and receive a confirmation flow before deletion.
  * Added an account deletion status page showing deletion details with options to abort deletion or sign out.
  * Abort deletion and sign-out actions provide success/error notifications and appropriate redirects.
  * Dashboard now redirects deleted accounts to the account deletion status page.

* **Refactor**
  * Reorganized modal components into the notification/provider area for cleaner layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->