### PR TITLE
Refactor Notification Mechanism

### DIFF
--- a/src/db/migrations/supabase/0008_whole_human_fly.sql
+++ b/src/db/migrations/supabase/0008_whole_human_fly.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "notification" ALTER COLUMN "payload" SET DATA TYPE jsonb;--> statement-breakpoint
+ALTER TABLE "notification" ALTER COLUMN "payload" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification_receiver" ADD COLUMN "created_at" timestamp (6) with time zone DEFAULT now() NOT NULL;--> statement-breakpoint
+ALTER TABLE "notification" DROP COLUMN "title";--> statement-breakpoint
+ALTER TABLE "notification" DROP COLUMN "body";--> statement-breakpoint
+ALTER TABLE "notification" DROP COLUMN "type";

--- a/src/db/migrations/supabase/0009_futuristic_infant_terrible.sql
+++ b/src/db/migrations/supabase/0009_futuristic_infant_terrible.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "notification_receiver" RENAME TO "notification_receive";--> statement-breakpoint
+ALTER TABLE "notification_receive" DROP CONSTRAINT "notification_receiver_notification_id_notification_id_fk";
+--> statement-breakpoint
+ALTER TABLE "notification_receive" DROP CONSTRAINT "notification_receiver_user_id_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "notification_receive" ADD CONSTRAINT "notification_receive_notification_id_notification_id_fk" FOREIGN KEY ("notification_id") REFERENCES "public"."notification"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "notification_receive" ADD CONSTRAINT "notification_receive_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "app_auth"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/db/migrations/supabase/0010_mysterious_violations.sql
+++ b/src/db/migrations/supabase/0010_mysterious_violations.sql
@@ -1,0 +1,6 @@
+DROP INDEX "public_notificationReceiver_notificationId_idx";--> statement-breakpoint
+DROP INDEX "public_notificationReceiver_userId_idx";--> statement-breakpoint
+ALTER TABLE "notification_receive" DROP CONSTRAINT "public_notificationReceiver_cpk";--> statement-breakpoint
+ALTER TABLE "notification_receive" ADD CONSTRAINT "public_notificationReceive_cpk" PRIMARY KEY("notification_id","user_id");--> statement-breakpoint
+CREATE INDEX "public_notificationReceive_notificationId_idx" ON "notification_receive" USING btree ("notification_id");--> statement-breakpoint
+CREATE INDEX "public_notificationReceive_userId_idx" ON "notification_receive" USING btree ("user_id");

--- a/src/db/migrations/supabase/meta/0008_snapshot.json
+++ b/src/db/migrations/supabase/meta/0008_snapshot.json
@@ -1,0 +1,1610 @@
+{
+  "id": "1803342a-ca8c-4be7-b922-3a5cab4a4cac",
+  "prevId": "838db6a9-35ae-4bf6-b4d8-f42aa4a6a044",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app_auth.account": {
+      "name": "account",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.session": {
+      "name": "session",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.user": {
+      "name": "user",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "onboarding_status_enum",
+          "typeSchema": "app_auth",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'name'"
+        },
+        "theme": {
+          "name": "theme",
+          "type": "theme_enum",
+          "typeSchema": "app_auth",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "is_silent": {
+          "name": "is_silent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "appAuth_user_deletedAt_idx": {
+          "name": "appAuth_user_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_username_unique": {
+          "name": "user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app_auth.verification": {
+      "name": "verification",
+      "schema": "app_auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.image": {
+      "name": "image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ownership": {
+          "name": "ownership",
+          "type": "media_ownership_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user_owned'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "media_storage": {
+          "name": "media_storage",
+          "type": "media_storage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_image_name_fts": {
+          "name": "public_image_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_image_tags_idx": {
+          "name": "public_image_tags_idx",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_image_ownerId_idx": {
+          "name": "public_image_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_image_deletedAt_idx": {
+          "name": "public_image_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "image_owner_id_user_id_fk": {
+          "name": "image_owner_id_user_id_fk",
+          "tableFrom": "image",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification": {
+      "name": "notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_receiver": {
+      "name": "notification_receiver",
+      "schema": "",
+      "columns": {
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_notificationReceiver_notificationId_idx": {
+          "name": "public_notificationReceiver_notificationId_idx",
+          "columns": [
+            {
+              "expression": "notification_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_notificationReceiver_userId_idx": {
+          "name": "public_notificationReceiver_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_receiver_notification_id_notification_id_fk": {
+          "name": "notification_receiver_notification_id_notification_id_fk",
+          "tableFrom": "notification_receiver",
+          "tableTo": "notification",
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_receiver_user_id_user_id_fk": {
+          "name": "notification_receiver_user_id_user_id_fk",
+          "tableFrom": "notification_receiver",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "public_notificationReceiver_cpk": {
+          "name": "public_notificationReceiver_cpk",
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_project_name_fts": {
+          "name": "public_project_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english',\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_project_isPinned_idx": {
+          "name": "public_project_isPinned_idx",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_isArchived_idx": {
+          "name": "public_project_isArchived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_createdById_idx": {
+          "name": "public_project_createdById_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_ownerId_idx": {
+          "name": "public_project_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_createdAt_idx": {
+          "name": "public_project_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_updatedAt_idx": {
+          "name": "public_project_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_project_deletedAt_idx": {
+          "name": "public_project_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_created_by_id_user_id_fk": {
+          "name": "project_created_by_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "project_owner_id_user_id_fk": {
+          "name": "project_owner_id_user_id_fk",
+          "tableFrom": "project",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_membership": {
+      "name": "project_membership",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "project_membership_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_membership_project_id_project_id_fk": {
+          "name": "project_membership_project_id_project_id_fk",
+          "tableFrom": "project_membership",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_membership_user_id_user_id_fk": {
+          "name": "project_membership_user_id_user_id_fk",
+          "tableFrom": "project_membership",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "public_projectMembership_cpk": {
+          "name": "public_projectMembership_cpk",
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.task": {
+      "name": "task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "task_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_by_id": {
+          "name": "claimed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_by_id": {
+          "name": "completed_by_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "public_task_name_fts": {
+          "name": "public_task_name_fts",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "public_task_priority_idx": {
+          "name": "public_task_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_status_idx": {
+          "name": "public_task_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_createdById_idx": {
+          "name": "public_task_createdById_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_ownerId_idx": {
+          "name": "public_task_ownerId_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_claimedById_idx": {
+          "name": "public_task_claimedById_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_completedById_idx": {
+          "name": "public_task_completedById_idx",
+          "columns": [
+            {
+              "expression": "completed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_isPinned_idx": {
+          "name": "public_task_isPinned_idx",
+          "columns": [
+            {
+              "expression": "is_pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_isArchived_idx": {
+          "name": "public_task_isArchived_idx",
+          "columns": [
+            {
+              "expression": "is_archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_projectId_idx": {
+          "name": "public_task_projectId_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_parentId_idx": {
+          "name": "public_task_parentId_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_startAt_idx": {
+          "name": "public_task_startAt_idx",
+          "columns": [
+            {
+              "expression": "start_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_endAt_idx": {
+          "name": "public_task_endAt_idx",
+          "columns": [
+            {
+              "expression": "end_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_completedAt_idx": {
+          "name": "public_task_completedAt_idx",
+          "columns": [
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_createdAt_idx": {
+          "name": "public_task_createdAt_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_updatedAt_idx": {
+          "name": "public_task_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "public_task_deletedAt_idx": {
+          "name": "public_task_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_created_by_id_user_id_fk": {
+          "name": "task_created_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_owner_id_user_id_fk": {
+          "name": "task_owner_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_claimed_by_id_user_id_fk": {
+          "name": "task_claimed_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "claimed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_completed_by_id_user_id_fk": {
+          "name": "task_completed_by_id_user_id_fk",
+          "tableFrom": "task",
+          "tableTo": "user",
+          "schemaTo": "app_auth",
+          "columnsFrom": [
+            "completed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_project_id_project_id_fk": {
+          "name": "task_project_id_project_id_fk",
+          "tableFrom": "task",
+          "tableTo": "project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_task_parentId_fk": {
+          "name": "public_task_parentId_fk",
+          "tableFrom": "task",
+          "tableTo": "task",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.media_ownership_enum": {
+      "name": "media_ownership_enum",
+      "schema": "public",
+      "values": [
+        "system",
+        "user_owned"
+      ]
+    },
+    "public.media_storage": {
+      "name": "media_storage",
+      "schema": "public",
+      "values": [
+        "internal",
+        "external"
+      ]
+    },
+    "public.notification_type_enum": {
+      "name": "notification_type_enum",
+      "schema": "public",
+      "values": [
+        "project_invitation",
+        "created_new_task",
+        "claimed_task",
+        "assigned_task",
+        "completed_task",
+        "rejected_invitation",
+        "joined_project",
+        "left_project",
+        "promoted_member",
+        "demoted_member",
+        "archived_task",
+        "updated_task",
+        "new_message",
+        "system_alert",
+        "generic_broadcast",
+        "system_broadcast",
+        "system_positive",
+        "system_negative"
+      ]
+    },
+    "app_auth.onboarding_status_enum": {
+      "name": "onboarding_status_enum",
+      "schema": "app_auth",
+      "values": [
+        "name",
+        "username",
+        "image",
+        "settings",
+        "completed"
+      ]
+    },
+    "public.project_membership_type_enum": {
+      "name": "project_membership_type_enum",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "observer"
+      ]
+    },
+    "public.task_status_enum": {
+      "name": "task_status_enum",
+      "schema": "public",
+      "values": [
+        "pending",
+        "on_process",
+        "aborted",
+        "delayed",
+        "continued"
+      ]
+    },
+    "app_auth.theme_enum": {
+      "name": "theme_enum",
+      "schema": "app_auth",
+      "values": [
+        "default",
+        "dark",
+        "popBella",
+        "beigeSerenity",
+        "brownBear",
+        "coffeePuff",
+        "jetBlack"
+      ]
+    }
+  },
+  "schemas": {
+    "app_auth": "app_auth"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/supabase/meta/0009_snapshot.json
+++ b/src/db/migrations/supabase/meta/0009_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1803342a-ca8c-4be7-b922-3a5cab4a4cac",
-  "prevId": "838db6a9-35ae-4bf6-b4d8-f42aa4a6a044",
+  "id": "e4541b45-b4a6-4e61-a0f0-2117384fc735",
+  "prevId": "1803342a-ca8c-4be7-b922-3a5cab4a4cac",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -111,8 +111,12 @@
           "tableFrom": "account",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -200,8 +204,12 @@
           "tableFrom": "session",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -211,7 +219,9 @@
         "session_token_unique": {
           "name": "session_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": [
+            "token"
+          ]
         }
       },
       "policies": {},
@@ -338,12 +348,16 @@
         "user_username_unique": {
           "name": "user_username_unique",
           "nullsNotDistinct": false,
-          "columns": ["username"]
+          "columns": [
+            "username"
+          ]
         },
         "user_email_unique": {
           "name": "user_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ]
         }
       },
       "policies": {},
@@ -549,8 +563,12 @@
           "tableFrom": "image",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -593,8 +611,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.notification_receiver": {
-      "name": "notification_receiver",
+    "public.notification_receive": {
+      "name": "notification_receive",
       "schema": "",
       "columns": {
         "notification_id": {
@@ -663,22 +681,30 @@
         }
       },
       "foreignKeys": {
-        "notification_receiver_notification_id_notification_id_fk": {
-          "name": "notification_receiver_notification_id_notification_id_fk",
-          "tableFrom": "notification_receiver",
+        "notification_receive_notification_id_notification_id_fk": {
+          "name": "notification_receive_notification_id_notification_id_fk",
+          "tableFrom": "notification_receive",
           "tableTo": "notification",
-          "columnsFrom": ["notification_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "notification_receiver_user_id_user_id_fk": {
-          "name": "notification_receiver_user_id_user_id_fk",
-          "tableFrom": "notification_receiver",
+        "notification_receive_user_id_user_id_fk": {
+          "name": "notification_receive_user_id_user_id_fk",
+          "tableFrom": "notification_receive",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -686,7 +712,10 @@
       "compositePrimaryKeys": {
         "public_notificationReceiver_cpk": {
           "name": "public_notificationReceiver_cpk",
-          "columns": ["notification_id", "user_id"]
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -890,8 +919,12 @@
           "tableFrom": "project",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["created_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -900,8 +933,12 @@
           "tableFrom": "project",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -961,8 +998,12 @@
           "name": "project_membership_project_id_project_id_fk",
           "tableFrom": "project_membership",
           "tableTo": "project",
-          "columnsFrom": ["project_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -971,8 +1012,12 @@
           "tableFrom": "project_membership",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -980,7 +1025,10 @@
       "compositePrimaryKeys": {
         "public_projectMembership_cpk": {
           "name": "public_projectMembership_cpk",
-          "columns": ["project_id", "user_id"]
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -1375,8 +1423,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["created_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1385,8 +1437,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1395,8 +1451,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["claimed_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "claimed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1405,8 +1465,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["completed_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "completed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1414,8 +1478,12 @@
           "name": "task_project_id_project_id_fk",
           "tableFrom": "task",
           "tableTo": "project",
-          "columnsFrom": ["project_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1423,8 +1491,12 @@
           "name": "public_task_parentId_fk",
           "tableFrom": "task",
           "tableTo": "task",
-          "columnsFrom": ["parent_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1440,12 +1512,18 @@
     "public.media_ownership_enum": {
       "name": "media_ownership_enum",
       "schema": "public",
-      "values": ["system", "user_owned"]
+      "values": [
+        "system",
+        "user_owned"
+      ]
     },
     "public.media_storage": {
       "name": "media_storage",
       "schema": "public",
-      "values": ["internal", "external"]
+      "values": [
+        "internal",
+        "external"
+      ]
     },
     "public.notification_type_enum": {
       "name": "notification_type_enum",
@@ -1474,17 +1552,34 @@
     "app_auth.onboarding_status_enum": {
       "name": "onboarding_status_enum",
       "schema": "app_auth",
-      "values": ["name", "username", "image", "settings", "completed"]
+      "values": [
+        "name",
+        "username",
+        "image",
+        "settings",
+        "completed"
+      ]
     },
     "public.project_membership_type_enum": {
       "name": "project_membership_type_enum",
       "schema": "public",
-      "values": ["owner", "admin", "member", "observer"]
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "observer"
+      ]
     },
     "public.task_status_enum": {
       "name": "task_status_enum",
       "schema": "public",
-      "values": ["pending", "on_process", "aborted", "delayed", "continued"]
+      "values": [
+        "pending",
+        "on_process",
+        "aborted",
+        "delayed",
+        "continued"
+      ]
     },
     "app_auth.theme_enum": {
       "name": "theme_enum",

--- a/src/db/migrations/supabase/meta/0010_snapshot.json
+++ b/src/db/migrations/supabase/meta/0010_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1803342a-ca8c-4be7-b922-3a5cab4a4cac",
-  "prevId": "838db6a9-35ae-4bf6-b4d8-f42aa4a6a044",
+  "id": "98a18152-5da1-4a29-a412-dea619a4fe2c",
+  "prevId": "e4541b45-b4a6-4e61-a0f0-2117384fc735",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -111,8 +111,12 @@
           "tableFrom": "account",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -200,8 +204,12 @@
           "tableFrom": "session",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -211,7 +219,9 @@
         "session_token_unique": {
           "name": "session_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": [
+            "token"
+          ]
         }
       },
       "policies": {},
@@ -338,12 +348,16 @@
         "user_username_unique": {
           "name": "user_username_unique",
           "nullsNotDistinct": false,
-          "columns": ["username"]
+          "columns": [
+            "username"
+          ]
         },
         "user_email_unique": {
           "name": "user_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ]
         }
       },
       "policies": {},
@@ -549,8 +563,12 @@
           "tableFrom": "image",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -593,8 +611,8 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.notification_receiver": {
-      "name": "notification_receiver",
+    "public.notification_receive": {
+      "name": "notification_receive",
       "schema": "",
       "columns": {
         "notification_id": {
@@ -631,8 +649,8 @@
         }
       },
       "indexes": {
-        "public_notificationReceiver_notificationId_idx": {
-          "name": "public_notificationReceiver_notificationId_idx",
+        "public_notificationReceive_notificationId_idx": {
+          "name": "public_notificationReceive_notificationId_idx",
           "columns": [
             {
               "expression": "notification_id",
@@ -646,8 +664,8 @@
           "method": "btree",
           "with": {}
         },
-        "public_notificationReceiver_userId_idx": {
-          "name": "public_notificationReceiver_userId_idx",
+        "public_notificationReceive_userId_idx": {
+          "name": "public_notificationReceive_userId_idx",
           "columns": [
             {
               "expression": "user_id",
@@ -663,30 +681,41 @@
         }
       },
       "foreignKeys": {
-        "notification_receiver_notification_id_notification_id_fk": {
-          "name": "notification_receiver_notification_id_notification_id_fk",
-          "tableFrom": "notification_receiver",
+        "notification_receive_notification_id_notification_id_fk": {
+          "name": "notification_receive_notification_id_notification_id_fk",
+          "tableFrom": "notification_receive",
           "tableTo": "notification",
-          "columnsFrom": ["notification_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "notification_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
-        "notification_receiver_user_id_user_id_fk": {
-          "name": "notification_receiver_user_id_user_id_fk",
-          "tableFrom": "notification_receiver",
+        "notification_receive_user_id_user_id_fk": {
+          "name": "notification_receive_user_id_user_id_fk",
+          "tableFrom": "notification_receive",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {
-        "public_notificationReceiver_cpk": {
-          "name": "public_notificationReceiver_cpk",
-          "columns": ["notification_id", "user_id"]
+        "public_notificationReceive_cpk": {
+          "name": "public_notificationReceive_cpk",
+          "columns": [
+            "notification_id",
+            "user_id"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -890,8 +919,12 @@
           "tableFrom": "project",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["created_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -900,8 +933,12 @@
           "tableFrom": "project",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -961,8 +998,12 @@
           "name": "project_membership_project_id_project_id_fk",
           "tableFrom": "project_membership",
           "tableTo": "project",
-          "columnsFrom": ["project_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -971,8 +1012,12 @@
           "tableFrom": "project_membership",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -980,7 +1025,10 @@
       "compositePrimaryKeys": {
         "public_projectMembership_cpk": {
           "name": "public_projectMembership_cpk",
-          "columns": ["project_id", "user_id"]
+          "columns": [
+            "project_id",
+            "user_id"
+          ]
         }
       },
       "uniqueConstraints": {},
@@ -1375,8 +1423,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["created_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1385,8 +1437,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["owner_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1395,8 +1451,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["claimed_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "claimed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1405,8 +1465,12 @@
           "tableFrom": "task",
           "tableTo": "user",
           "schemaTo": "app_auth",
-          "columnsFrom": ["completed_by_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "completed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1414,8 +1478,12 @@
           "name": "task_project_id_project_id_fk",
           "tableFrom": "task",
           "tableTo": "project",
-          "columnsFrom": ["project_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         },
@@ -1423,8 +1491,12 @@
           "name": "public_task_parentId_fk",
           "tableFrom": "task",
           "tableTo": "task",
-          "columnsFrom": ["parent_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1440,12 +1512,18 @@
     "public.media_ownership_enum": {
       "name": "media_ownership_enum",
       "schema": "public",
-      "values": ["system", "user_owned"]
+      "values": [
+        "system",
+        "user_owned"
+      ]
     },
     "public.media_storage": {
       "name": "media_storage",
       "schema": "public",
-      "values": ["internal", "external"]
+      "values": [
+        "internal",
+        "external"
+      ]
     },
     "public.notification_type_enum": {
       "name": "notification_type_enum",
@@ -1474,17 +1552,34 @@
     "app_auth.onboarding_status_enum": {
       "name": "onboarding_status_enum",
       "schema": "app_auth",
-      "values": ["name", "username", "image", "settings", "completed"]
+      "values": [
+        "name",
+        "username",
+        "image",
+        "settings",
+        "completed"
+      ]
     },
     "public.project_membership_type_enum": {
       "name": "project_membership_type_enum",
       "schema": "public",
-      "values": ["owner", "admin", "member", "observer"]
+      "values": [
+        "owner",
+        "admin",
+        "member",
+        "observer"
+      ]
     },
     "public.task_status_enum": {
       "name": "task_status_enum",
       "schema": "public",
-      "values": ["pending", "on_process", "aborted", "delayed", "continued"]
+      "values": [
+        "pending",
+        "on_process",
+        "aborted",
+        "delayed",
+        "continued"
+      ]
     },
     "app_auth.theme_enum": {
       "name": "theme_enum",

--- a/src/db/migrations/supabase/meta/_journal.json
+++ b/src/db/migrations/supabase/meta/_journal.json
@@ -64,6 +64,20 @@
       "when": 1765876643928,
       "tag": "0008_whole_human_fly",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1765877259210,
+      "tag": "0009_futuristic_infant_terrible",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1765877358345,
+      "tag": "0010_mysterious_violations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/supabase/meta/_journal.json
+++ b/src/db/migrations/supabase/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1765669760686,
       "tag": "0007_flimsy_phil_sheldon",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1765876643928,
+      "tag": "0008_whole_human_fly",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/auth-schema.ts
+++ b/src/db/schema/auth-schema.ts
@@ -12,7 +12,7 @@ import {
   themeEnum,
 } from "./configs";
 import { image } from "./image";
-import { notificationReceiver } from "./notification";
+import { notificationReceive } from "./notification";
 import { project, projectMembership } from "./project";
 import { task } from "./task";
 
@@ -113,7 +113,7 @@ export const userRelations = relations(user, ({ many }) => ({
   projects: many(project),
   tasks: many(task),
   projectMemberships: many(projectMembership),
-  notificationsReceived: many(notificationReceiver),
+  notificationsReceived: many(notificationReceive),
   images: many(image),
 }));
 

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -13,8 +13,8 @@ import { image, imageRelations } from "./image";
 // Notification
 import {
   notification,
-  notificationReceiver,
-  notificationReceiverRelations,
+  notificationReceive,
+  notificationReceiveRelations,
 } from "./notification";
 // Project Schema
 import {
@@ -49,8 +49,8 @@ const schema = {
 
   // Notification
   notification,
-  notificationReceiver,
-  notificationReceiverRelations,
+  notificationReceive,
+  notificationReceiveRelations,
 
   // Image
   image,

--- a/src/db/schema/notification.ts
+++ b/src/db/schema/notification.ts
@@ -21,8 +21,8 @@ export const notification = pgTable("notification", {
     .defaultNow(),
 });
 
-export const notificationReceiver = pgTable(
-  "notification_receiver",
+export const notificationReceive = pgTable(
+  "notification_receive",
   {
     notificationId: uuid("notification_id").references(() => notification.id, {
       onDelete: "cascade",
@@ -37,24 +37,22 @@ export const notificationReceiver = pgTable(
   (t) => [
     primaryKey({
       columns: [t.notificationId, t.userId],
-      name: "public_notificationReceiver_cpk",
+      name: "public_notificationReceive_cpk",
     }),
-    index("public_notificationReceiver_notificationId_idx").on(
-      t.notificationId,
-    ),
-    index("public_notificationReceiver_userId_idx").on(t.userId),
+    index("public_notificationReceive_notificationId_idx").on(t.notificationId),
+    index("public_notificationReceive_userId_idx").on(t.userId),
   ],
 );
 
-export const notificationReceiverRelations = relations(
-  notificationReceiver,
+export const notificationReceiveRelations = relations(
+  notificationReceive,
   ({ one }) => ({
     notification: one(notification, {
-      fields: [notificationReceiver.notificationId],
+      fields: [notificationReceive.notificationId],
       references: [notification.id],
     }),
     user: one(user, {
-      fields: [notificationReceiver.userId],
+      fields: [notificationReceive.userId],
       references: [user.id],
     }),
   }),

--- a/src/lib/app/app.d.ts
+++ b/src/lib/app/app.d.ts
@@ -167,7 +167,7 @@ export type NotificationPayload =
   | {
       type: "updated_a_task";
       actor: SanitizedUserType;
-      project: SanitizedUserType;
+      project: ProjectType;
       task: TaskType;
       message?: NotificationMessageType;
     }

--- a/src/lib/app/app.d.ts
+++ b/src/lib/app/app.d.ts
@@ -83,6 +83,7 @@ export type SanitizedUserType = Pick<
   "id" | "name" | "username" | "image"
 >;
 
+// PROJECTS
 export type ExtendedProjectMembershipType = ProjectMembershipType & {
   member?: SanitizedUserType | null;
 };
@@ -91,6 +92,7 @@ export type ExtendedProjectType = ProjectType & {
   memberships: ExtendedProjectMembershipType[];
 };
 
+// TASKS
 export type ExtendedTaskType = TaskType & {
   children?: TaskType[] | null;
   claimedBy?: SanitizedUserType | null;
@@ -100,3 +102,81 @@ export type ExtendedTaskType = TaskType & {
   project?: ProjectType | null;
   parent?: TaskType | null;
 };
+
+// NOTIFICATIONS
+export type NotificationMessageType = {
+  subject?: string;
+  message?: string;
+};
+
+export type NotificationPayload =
+  | {
+      type: "invited_to_a_project";
+      sender: SanitizedUserType;
+      project: ProjectType;
+      role: ProjectMembershipType["type"];
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "requested_a_promotion";
+      sender: SanitizedUserType;
+      project: ProjectType;
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "promoted";
+      actor: SanitizedUserType;
+      target: SanitizedUserType;
+      project: ProjectType;
+      roleBefore: ProjectMembershipType["type"];
+      roleNow: ProjectMembershipType["type"];
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "demoted";
+      actor: SanitizedUserType;
+      target: SanitizedUserType;
+      project: ProjectType;
+      roleBefore: ProjectMembershipType["type"];
+      roleNow: ProjectMembershipType["type"];
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "suspended";
+      actor: SanitizedUserType;
+      target: SanitizedUserType;
+      project: ProjectType;
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "claimed_a_task";
+      actor: SanitizedUserType;
+      target: SanitizedUserType;
+      project: ProjectType;
+      task: TaskType;
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "assigned_a_task";
+      actor: SanitizedUserType;
+      target: SanitizedUserType;
+      project: ProjectType;
+      task: TaskType;
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "updated_a_task";
+      actor: SanitizedUserType;
+      project: SanitizedUserType;
+      task: TaskType;
+      message?: NotificationMessageType;
+    }
+  | {
+      type: "message";
+      actor: SanitizedUserType | "system";
+      message: NotificationMessageType;
+      project?: ProjectType;
+      task?: TaskType;
+    };
+
+export type NotificationType = NotificationPayload["type"];


### PR DESCRIPTION
- Remove dedicated title,body and type fields from notification table
- Refactor notification payload, use flexible union type
- add created_at field on notification_receiver table
- change notification_receiver table to notification_receive


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications expanded with richer event types (invitations, promotions, task assignments, messages) and structured message payloads.
  * Tasks now surface more ownership and provenance details (owner, creator, completer).

* **Chores**
  * Data model and storage improved for notifications, including timestamps and stronger payload handling for reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->